### PR TITLE
Abacus matching

### DIFF
--- a/api/fastpm/cosmology.h
+++ b/api/fastpm/cosmology.h
@@ -12,16 +12,19 @@ struct FastPMCosmology {
     double h;
     double Omega_m;
     double Omega_cdm;
+    double Omega_ncdm;
     double Omega_k;
-    double Omega_Lambda;  // Omega of dark energy at z=0
+    double Omega_Lambda;     // Omega of dark energy at z=0
     double w0;
     double wa;
     double T_cmb;
-    //double T_nu;     // todays neutrino temperature HARD CODED FOR NOW
+    //double T_nu;           // todays neutrino temperature HARD CODED FOR NOW
     double N_eff;
-    int N_nu;          // total number of neutrino species (massive and massless)
-    double m_ncdm[3];  // masses of massive neutrinos (ncdm) for now assume max of 3 ncdms
+    int N_nu;                // total number of neutrino species (massive and massless)
+    double m_ncdm[3];        // masses of massive neutrinos (ncdm) for now assume max of 3 ncdms
     int N_ncdm;
+    int ncdm_freestreaming;  // bool: treat ncdm as free-streaming?
+    int ncdm_matterlike;     // bool: treat ncdm as matter-like?
 
     FastPMGrowthMode growth_mode;
     FastPMFDInterp * FDinterp;
@@ -47,6 +50,7 @@ double D2Omega_DE_TimesHubbleEaSqDa2(double a, FastPMCosmology * c);
 double HubbleEa(double a, FastPMCosmology * c);
 double Omega_cdm_a(double a, FastPMCosmology * c);
 double Omega_m(double a, FastPMCosmology * c);
+double Omega_source(double a, FastPMCosmology * c);
 double DHubbleEaDa(double a, FastPMCosmology * c);
 double D2HubbleEaDa2(double a, FastPMCosmology * c);
 

--- a/libfastpm/cosmology.c
+++ b/libfastpm/cosmology.c
@@ -195,9 +195,9 @@ double HubbleEa(double a, FastPMCosmology * c)
 
     return sqrt(Omega_r(c) / (a*a*a*a)
                 + c->Omega_cdm / (a*a*a)
-                + Omega_ncdm_ESq
                 + c->Omega_k / (a*a)
-                + Omega_DE_TimesHubbleEaSq(a, c));
+                + Omega_DE_TimesHubbleEaSq(a, c)
+                + Omega_ncdm_ESq);
 }
 
 double Omega_cdm_a(double a, FastPMCosmology * c)
@@ -229,18 +229,18 @@ double DHubbleEaDa(double a, FastPMCosmology * c)
     double E = HubbleEa(a, c);
     double DOdeESqDa = DOmega_DE_TimesHubbleEaSqDa(a, c);
 
-    double ncdm_contrib;   // contribution from ncdm
+    double DOncdmESqDa;   // contribution from ncdm
     if (c->ncdm_matterlike) {
-        ncdm_contrib = - 3 * c->Omega_ncdm / pow(a,4);
+        DOncdmESqDa = - 3 * c->Omega_ncdm / pow(a,4);
     } else {
-        ncdm_contrib = DOmega_ncdmTimesHubbleEaSqDa(a, c);
+        DOncdmESqDa = DOmega_ncdmTimesHubbleEaSqDa(a, c);
     }
 
     return 0.5 / E * (- 4 * Omega_r(c) / pow(a,5)
-                      + ncdm_contrib
                       - 3 * c->Omega_cdm / pow(a,4)
                       - 2 * c->Omega_k / pow(a,3)
-                      + DOdeESqDa);
+                      + DOdeESqDa
+                      + DOncdmESqDa);
 }
 
 double D2HubbleEaDa2(double a, FastPMCosmology * c)
@@ -249,18 +249,18 @@ double D2HubbleEaDa2(double a, FastPMCosmology * c)
     double dEda = DHubbleEaDa(a, c);
     double D2OdeESqDa2 = D2Omega_DE_TimesHubbleEaSqDa2(a, c);
 
-    double ncdm_contrib;   // contribution from ncdm
+    double D2OncdmESqDa2;   // contribution from ncdm
     if (c->ncdm_matterlike) {
-        ncdm_contrib = 12 * c->Omega_ncdm / pow(a,5);
+        D2OncdmESqDa2 = 12 * c->Omega_ncdm / pow(a,5);
     } else {
-        ncdm_contrib = D2Omega_ncdmTimesHubbleEaSqDa2(a, c);
+        D2OncdmESqDa2 = D2Omega_ncdmTimesHubbleEaSqDa2(a, c);
     }
 
     return 0.5 / E * (  20 * Omega_r(c) / pow(a,6)
                       + 12 * c->Omega_cdm / pow(a,5)
-                      + ncdm_contrib
                       + 6 * c->Omega_k / pow(a,4)
                       + D2OdeESqDa2
+                      + D2OncdmESqDa2
                       - 2 * pow(dEda,2) );
 }
 

--- a/libfastpm/cosmology.c
+++ b/libfastpm/cosmology.c
@@ -97,6 +97,7 @@ static double Fconst(int ncdm_id, FastPMCosmology * c)
 double Omega_ncdm_iTimesHubbleEaSq(double a, int ncdm_id, FastPMCosmology * c)   
 {
     /* Omega_ncdm_i(a) * E(a)^2 */
+    /* Could change to 93.14 explicitly for Abacus, but this is correct anyway */
     
     double A = 15. / pow(M_PI, 4) * pow(Gamma_nu(c), 4) * Omega_g(c);
     double Fc = Fconst(ncdm_id, c);
@@ -172,13 +173,13 @@ double D2Omega_DE_TimesHubbleEaSqDa2(double a, FastPMCosmology * c)
 
 double HubbleEa(double a, FastPMCosmology * c)
 {
-    /* H(a) / H0 
-       ncdm is NOT assumed to be matter like here */
+    /* H(a) / H0
+       ncdm is NOT assumed to be matter like here
+       CHANGED FOR ABACUS: NCDM assumed to be matter-like in background. */
     return sqrt(Omega_r(c) / (a*a*a*a)
-                + c->Omega_cdm / (a*a*a)
+                + c->Omega_m / (a*a*a)
                 + c->Omega_k / (a*a)
-                + Omega_DE_TimesHubbleEaSq(a, c)
-                + Omega_ncdmTimesHubbleEaSq(a, c));
+                + Omega_DE_TimesHubbleEaSq(a, c));
 }
 
 double Omega_cdm_a(double a, FastPMCosmology * c)
@@ -203,10 +204,9 @@ double DHubbleEaDa(double a, FastPMCosmology * c)
     double DOncdmESqDa = DOmega_ncdmTimesHubbleEaSqDa(a, c);
     
     return 0.5 / E * ( - 4 * Omega_r(c) / pow(a,5)
-                      - 3 * c->Omega_cdm / pow(a,4)
+                      - 3 * c->Omega_m / pow(a,4)
                       - 2 * c->Omega_k / pow(a,3)
-                      + DOdeESqDa
-                      + DOncdmESqDa);
+                      + DOdeESqDa);
 }
 
 double D2HubbleEaDa2(double a, FastPMCosmology * c)
@@ -217,10 +217,9 @@ double D2HubbleEaDa2(double a, FastPMCosmology * c)
     double D2OncdmESqDa2 = D2Omega_ncdmTimesHubbleEaSqDa2(a, c);
 
     return 0.5 / E * ( 20 * Omega_r(c) / pow(a,6)
-                      + 12 * c->Omega_cdm / pow(a,5)
+                      + 12 * c->Omega_m / pow(a,5)
                       + 6 * c->Omega_k / pow(a,4)
                       + D2OdeESqDa2
-                      + D2OncdmESqDa2
                       - 2 * pow(dEda,2) );
 }
 
@@ -266,9 +265,9 @@ static int growth_ode(double a, const double y[], double dyda[], void *params)
     
     double dydlna[4];
     dydlna[0] = y[1];
-    dydlna[1] = - (2. + a / E * dEda) * y[1] + 1.5 * Omega_m(a, c) * y[0];
+    dydlna[1] = - (2. + a / E * dEda) * y[1] + 1.5 * Omega_cdm_a(a, c) * y[0];
     dydlna[2] = y[3];
-    dydlna[3] = - (2. + a / E * dEda) * y[3] + 1.5 * Omega_m(a, c) * (y[2] - y[0]*y[0]);
+    dydlna[3] = - (2. + a / E * dEda) * y[3] + 1.5 * Omega_cdm_a(a, c) * (y[2] - y[0]*y[0]);
     
     //divide by  a to get dyda
     for (int i=0; i<4; i++){
@@ -401,7 +400,7 @@ double D2GrowthFactorDa2(FastPMGrowthInfo * growth_info) {
             double f1 = growth_info->f1;
 
             ans -= (3. + a / E * dEda) * f1;
-            ans += 1.5 * Omega_m(a, c);
+            ans += 1.5 * Omega_cdm_a(a, c);
             ans *= D1 / (a*a);
         break; }
         default:

--- a/libfastpm/cosmology.c
+++ b/libfastpm/cosmology.c
@@ -29,8 +29,14 @@ fastpm_cosmology_init(FastPMCosmology * c)
         c->FDinterp = FDinterp;
     }
 
-    // Compute Omega_cdm assuming all ncdm is matter like
-    c->Omega_cdm = c->Omega_m - Omega_ncdmTimesHubbleEaSq(1, c);
+    double Omega_ncdm_0 = 0;
+    for (int i=0; i<c->N_ncdm; i++) {
+        Omega_ncdm_0 += c->m_ncdm[i];
+    }
+    Omega_ncdm_0 *= 1. / 93.14 / c->h / c->h;
+
+    // Compute Omega_cdm assuming all ncdm is matter like using the above 93.14 eqn
+    c->Omega_cdm = c->Omega_m - Omega_ncdm_0;
 
     // Set Omega_Lambda at z=0 by closing Friedmann's equation
     c->Omega_Lambda = 1 - c->Omega_m - Omega_r(c) - c->Omega_k;

--- a/libfastpm/factors.c
+++ b/libfastpm/factors.c
@@ -253,8 +253,8 @@ void fastpm_kick_init(FastPMKickFactor * kick, FastPMSolver * fastpm, double ai,
     double D1_c = gi_c.D1;
     double D2_c = gi_c.D2;
 
-    double Omega_m0 = c->Omega_cdm;
-    double Omega_mc = Omega_cdm_a(ac, c);   // For Abacus only use cdm for poisson source term
+    double Omega_m0 = Omega_source(1, c);
+    double Omega_mc = Omega_source(ac, c);
 
     // kick->q1,2 are used for the COLA force implementation.
     // growth_mode = ODE and LCDM should match for an LCDM background,

--- a/libfastpm/factors.c
+++ b/libfastpm/factors.c
@@ -253,8 +253,8 @@ void fastpm_kick_init(FastPMKickFactor * kick, FastPMSolver * fastpm, double ai,
     double D1_c = gi_c.D1;
     double D2_c = gi_c.D2;
 
-    double Omega_m0 = c->Omega_m;
-    double Omega_mc = Omega_m(ac, c);   // assumes all ncdm is matter like
+    double Omega_m0 = c->Omega_cdm;
+    double Omega_mc = Omega_cdm_a(ac, c);   // For Abacus only use cdm for poisson source term
 
     // kick->q1,2 are used for the COLA force implementation.
     // growth_mode = ODE and LCDM should match for an LCDM background,

--- a/libfastpm/solver.c
+++ b/libfastpm/solver.c
@@ -674,7 +674,7 @@ fastpm_set_species_snapshot(FastPMSolver * fastpm,
     /* convert units */
 
     /* potfactor converts fastpm Phi to dimensionless */
-    double potfactor = 1.5 * c->Omega_m / (HubbleDistance * HubbleDistance);
+    double potfactor = 1.5 * c->Omega_cdm / (HubbleDistance * HubbleDistance);
 
 #pragma omp parallel for
     for(i=0; i<np; i++) {
@@ -715,7 +715,7 @@ fastpm_unset_species_snapshot(FastPMSolver * fastpm,
     /* convert units */
 
     /* potfactor converts fastpm Phi to dimensionless */
-    double potfactor = 1.5 * c->Omega_m / (HubbleDistance * HubbleDistance);
+    double potfactor = 1.5 * c->Omega_cdm / (HubbleDistance * HubbleDistance);
 
 #pragma omp parallel for
     for(i=0; i<np; i++) {

--- a/libfastpm/solver.c
+++ b/libfastpm/solver.c
@@ -674,7 +674,7 @@ fastpm_set_species_snapshot(FastPMSolver * fastpm,
     /* convert units */
 
     /* potfactor converts fastpm Phi to dimensionless */
-    double potfactor = 1.5 * c->Omega_cdm / (HubbleDistance * HubbleDistance);
+    double potfactor = 1.5 * Omega_source(1, c) / (HubbleDistance * HubbleDistance);
 
 #pragma omp parallel for
     for(i=0; i<np; i++) {
@@ -715,7 +715,7 @@ fastpm_unset_species_snapshot(FastPMSolver * fastpm,
     /* convert units */
 
     /* potfactor converts fastpm Phi to dimensionless */
-    double potfactor = 1.5 * c->Omega_cdm / (HubbleDistance * HubbleDistance);
+    double potfactor = 1.5 * Omega_source(1, c) / (HubbleDistance * HubbleDistance);
 
 #pragma omp parallel for
     for(i=0; i<np; i++) {

--- a/libfastpm/thermalvelocity.c
+++ b/libfastpm/thermalvelocity.c
@@ -295,7 +295,7 @@ fastpm_ncdm_init_create(
     nid->n_ncdm = c->N_ncdm;
 
     /* Normalize Omega_ncdm assuming all ncdm is matter like. */
-    nid->Omega_ncdm = Omega_ncdmTimesHubbleEaSq(1, c);
+    nid->Omega_ncdm = c->Omega_ncdm;
     nid->z = z;
     fastpm_info("ncdm reference redshift = %g\n", z);
     nid->n_shells = n_shells;

--- a/libfastpm/thermalvelocity.c
+++ b/libfastpm/thermalvelocity.c
@@ -293,8 +293,6 @@ fastpm_ncdm_init_create(
         nid->m_ncdm_sum += c->m_ncdm[i];
     }
     nid->n_ncdm = c->N_ncdm;
-
-    /* Normalize Omega_ncdm assuming all ncdm is matter like. */
     nid->Omega_ncdm = c->Omega_ncdm;
     nid->z = z;
     fastpm_info("ncdm reference redshift = %g\n", z);

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -396,6 +396,8 @@ prepare_cosmology(FastPMCosmology * c, RunData * prr) {
     c->N_eff = CONF(prr->lua, N_eff);
     c->N_nu = CONF(prr->lua, N_nu);
     c->N_ncdm = CONF(prr->lua, n_m_ncdm);
+    c->ncdm_freestreaming = CONF(prr->lua, ncdm_freestreaming);
+    c->ncdm_matterlike = CONF(prr->lua, ncdm_matterlike);
     c->growth_mode = CONF(prr->lua, growth_mode);
 
     int i;

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -396,8 +396,8 @@ prepare_cosmology(FastPMCosmology * c, RunData * prr) {
     c->N_eff = CONF(prr->lua, N_eff);
     c->N_nu = CONF(prr->lua, N_nu);
     c->N_ncdm = CONF(prr->lua, n_m_ncdm);
-    c->ncdm_freestreaming = CONF(prr->lua, ncdm_freestreaming);
     c->ncdm_matterlike = CONF(prr->lua, ncdm_matterlike);
+    c->ncdm_freestreaming = CONF(prr->lua, ncdm_freestreaming);
     c->growth_mode = CONF(prr->lua, growth_mode);
 
     int i;

--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -85,10 +85,6 @@ function schema.T_cmb.action (T_cmb)
     
     function schema.m_ncdm.action (m_ncdm)
         if #m_ncdm ~= 0 then
-            if T_cmb == 0 then
-                error("For a run with ncdm particles use T_cmb > 0 to include an ncdm background.")
-            end
-
             for i=2, #m_ncdm do
                 if m_ncdm[i] > m_ncdm[1] then
                     error("Please input the heaviest ncdm particle first.")

--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -48,7 +48,7 @@ schema.declare{name='pm_nc_factor',      type='array:number',  required=true, he
 schema.declare{name='lpt_nc_factor',     type='number', required=false, default=1, help="PM resolution use in lpt and linear density field."}
 schema.declare{name='np_alloc_factor',   type='number', required=true, help="Over allocation factor for load imbalance" }
 schema.declare{name='compute_potential', type='boolean', required=false, default=false, help="Calculate the gravitional potential."}
-schema.declare{name='n_shell',           type='number', required=false, default=10, help="Number of shells of FD distribution for ncdm splitting."}
+schema.declare{name='n_shell',           type='number', required=false, default=10, help="Number of shells of FD distribution for ncdm splitting. Set n_shell=0 for no ncdm particles."}
 schema.declare{name='lvk',               type='boolean', required=false, default=true, help="Use the low velocity kernel when splitting FD for ncdm."}
 schema.declare{name='n_side',            type='number', required=false, default=3, help="This is N_fib for fibonacci sphere splitting, or number of sides in HEALPix splitting."}
 schema.declare{name='every_ncdm',        type='number', required=false, default=4, help="Subsample ncdm from cdm every..."}
@@ -57,6 +57,10 @@ schema.ncdm_sphere_scheme.choices = {
     healpix = 'FASTPM_NCDM_SPHERE_HEALPIX',
     fibonacci = 'FASTPM_NCDM_SPHERE_FIBONACCI',
 }
+schema.declare{name='ncdm_matterlike', type='boolean', required=false, default=true, help="Approximate ncdm as matter-like in the background? If true, Omega_ncdm~1/a^3."}
+schema.declare{name='ncdm_freestreaming', type='boolean', required=false, default=true, help="Treat ncdm as free-streaming? If true, source terms ~Omega_c; if false, ~Omega_m."}
+
+
 schema.declare{name='growth_mode', type='enum', default='ODE', help="Evaluate growth factors using a Lambda+CDM-only approximation or with the full ODE. " ..
                                                                      "The full ODE is required for accurate results for runs with radiation or varying DE in the background, " ..
                                                                      "and can also be used for Lambda+CDM-only backgrounds. " ..
@@ -88,6 +92,18 @@ function schema.T_cmb.action (T_cmb)
             for i=2, #m_ncdm do
                 if m_ncdm[i] > m_ncdm[1] then
                     error("Please input the heaviest ncdm particle first.")
+                end
+            end
+            function schema.n_shell.action (n_shell)
+                function schema.ncdm_freestreaming.action (ncdm_freestreaming)
+                    if ncdm_freestreaming and n_shell ~= 0 then
+                         error("For free-streaming ncdm use n_shell = 0 to turn off ncdm particles.")
+                    end
+                end
+            end
+            function schema.ncdm_matterlike.action (ncdm_matterlike)
+                if not ncdm_matterlike and T_cmb == 0 then
+                     error("For a run with exact Omega_ncdm, T_cmb > 0 is required.")
                 end
             end
         end

--- a/tests/ncdm.lua
+++ b/tests/ncdm.lua
@@ -30,9 +30,11 @@ N_nu    = 3                 -- number of neutrinos species (including massless s
 m_ncdm  = {0.12, 0.06, 0.02}
 n_shell = 10
 ncdm_sphere_scheme = "fibonacci"
-n_side  = 3      -- this is N_fib in the case of a fibaonacci sphere spitting scheme
-every_ncdm = 4   -- this defines the ratio of the cdm grid number to the ncdm grid number
-lvk = true       -- low velocity kernel: used for fermi-dirac sampling. g(q) = q f(q) in paper.
+n_side  = 3                 -- this is N_fib in the case of a fibaonacci sphere spitting scheme
+every_ncdm = 4              -- this defines the ratio of the cdm grid number to the ncdm grid number
+lvk = true                  -- low velocity kernel: used for fermi-dirac sampling. g(q) = q f(q) in paper
+ncdm_freestreaming = false  -- choose whether to treat ncdm as free-streaming for the growth ODE and Poisson source terms
+ncdm_matterlike = false     -- choose whether to approximate ncdm as matter-like in the background
 
 -------- Perturbations --------
 -- Input powerspectrum and growth rate


### PR DESCRIPTION
Abacus effectively runs with 

1 ) matter-like neutrinos in the bcakground, i.e. O_nu(a) = O_nu,0 / a^3,
2) only cdm in the Poisson source terms (for both the force and kick/drift factors),
3) no neutrino clustering (i.e. no neutrino particles).

In this branch we swap O_m and O_cdm as needed, and use matter-like O_nu. Started with explicitly replacement, but end goal of PR is to give user choice of options.

EDIT:
4) no radiation in the background.