### PR TITLE
Add a Rand column

### DIFF
--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -243,11 +243,6 @@ fastpm_store_fill_subsample_mask(FastPMStore * p,
         double fraction,
         FastPMParticleMaskType * mask);
 
-void
-fastpm_store_fill_subsample_mask_every_dim(FastPMStore * p,
-                                              int every,
-                                              FastPMParticleMaskType * mask);
-
 size_t
 fastpm_store_subsample(FastPMStore * in, FastPMParticleMaskType * mask, FastPMStore * out);
 

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -241,8 +241,7 @@ fastpm_store_get_mask_sum(FastPMStore * p, MPI_Comm comm);
 void
 fastpm_store_fill_subsample_mask(FastPMStore * p,
         double fraction,
-        FastPMParticleMaskType * mask,
-        MPI_Comm comm);
+        FastPMParticleMaskType * mask);
 
 void
 fastpm_store_fill_subsample_mask_every_dim(FastPMStore * p,

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -54,6 +54,7 @@ typedef enum FastPMColumnTags {
     COLUMN_RVDISP =  1L << 19,
     
     COLUMN_MASS = 1L << 20,
+    COLUMN_RAND = 1L << 21,
 
 } FastPMColumnTags;
 
@@ -124,6 +125,9 @@ struct FastPMStore {
 
             /* multiple species support */
             float (* mass);   /* extra mass in addition to meta.M0; see fastpm_store_get_mass */
+
+	    /* other fields */
+            float (* rand);   /* a random number between 0 and 1 */
         };
     };
 };

--- a/libfastpm/lightcone-usmesh.c
+++ b/libfastpm/lightcone-usmesh.c
@@ -82,8 +82,8 @@ fastpm_usmesh_init(FastPMUSMesh * mesh, FastPMLightCone * lc,
     mesh->p = malloc(sizeof(FastPMStore));
     /* for saving the density with particles */
     fastpm_store_init(mesh->p, source->name, np_upper,
-                  COLUMN_ID | COLUMN_POS | COLUMN_VEL | COLUMN_MASK
-                | COLUMN_AEMIT,
+                  COLUMN_ID | COLUMN_POS | COLUMN_VEL | COLUMN_MASK |
+                  COLUMN_RAND | COLUMN_AEMIT,
                 FASTPM_MEMORY_HEAP
     );
 
@@ -455,6 +455,8 @@ fastpm_usmesh_intersect_tile(FastPMUSMesh * mesh, double * tileshift,
                 pout->id[next] = p->id[i];
             if(pout->aemit)
                 pout->aemit[next] = a_emit;
+            if(pout->rand)
+                pout->rand[next] = p->rand[i];
             if(pout->mask)
                 pout->mask[next] = p->mask[i];
 

--- a/libfastpm/solver.c
+++ b/libfastpm/solver.c
@@ -91,7 +91,7 @@ void fastpm_solver_init(FastPMSolver * fastpm,
     fastpm_store_init_evenly(fastpm->cdm,
           fastpm_species_get_name(FASTPM_SPECIES_CDM),
           pow(1.0 * config->nc, 3),
-          COLUMN_POS | COLUMN_VEL | COLUMN_ID | COLUMN_MASK | COLUMN_ACC | config->ExtraAttributes,
+          COLUMN_POS | COLUMN_VEL | COLUMN_ID | COLUMN_MASK | COLUMN_RAND | COLUMN_ACC | config->ExtraAttributes,
           config->alloc_factor,
           comm);
 
@@ -147,7 +147,7 @@ void fastpm_solver_init(FastPMSolver * fastpm,
     }
     double shift[3] = {shift0, shift0, shift0};
 
-    fastpm_store_fill(fastpm_solver_get_species(fastpm, FASTPM_SPECIES_CDM), fastpm->basepm, shift, NULL);
+    fastpm_store_fill(fastpm->cdm, fastpm->basepm, shift, NULL);
 
     fastpm->pm = fastpm->lptpm;
 }

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -774,6 +774,8 @@ fastpm_store_fill(FastPMStore * p, PM * pm, double * shift, ptrdiff_t * Nc)
 
             if(p->id) p->id[ptr] = id;
             if(p->mask) p->mask[ptr] = 0;
+            /* FIXME: fill rand with a hash of the id instead of using
+             * _fastpm_store_fill_rand. */
             if(p->rand) p->rand[ptr] = 0.;
 
             fastpm_store_get_q_from_id(p, id, &p->x[ptr][0]);

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -206,6 +206,7 @@ fastpm_store_init_details(FastPMStore * p,
     DEFINE_COLUMN(vdisp, COLUMN_VDISP, "f4", 6);
     DEFINE_COLUMN(rvdisp, COLUMN_RVDISP, "f4", 9);
     DEFINE_COLUMN(mass, COLUMN_MASS, "f4", 1);
+    DEFINE_COLUMN(rand, COLUMN_RAND, "f4", 1);
 
     COLUMN_INFO(x).to_double = to_double_f8;
     COLUMN_INFO(v).to_double = to_double_f4;
@@ -688,6 +689,34 @@ fastpm_store_get_iq_from_id(FastPMStore * p, uint64_t id, ptrdiff_t pabs[3])
     }
 }
 
+static void
+_fastpm_store_fill_rand(FastPMStore * p, MPI_Comm comm)
+{
+    gsl_rng * random_generator = gsl_rng_alloc(gsl_rng_ranlxd1);
+    int ThisTask;
+    MPI_Comm_rank(comm, &ThisTask);
+
+    /* set uncorrelated seeds */
+    double seed=1231584; //FIXME: set this properly.
+    gsl_rng_set(random_generator, seed);
+    int d;
+
+    for(d = 0; d < ThisTask * 8; d++) {
+        seed = 0x7fffffff * gsl_rng_uniform(random_generator);
+    }
+
+    gsl_rng_set(random_generator, seed);
+
+    ptrdiff_t i;
+    for(i=0; i < p->np_upper; i++) {
+        double rand_i = gsl_rng_uniform(random_generator);
+	p->rand[i] = rand_i;
+    }
+
+    gsl_rng_free(random_generator);
+
+}
+
 void
 fastpm_store_fill(FastPMStore * p, PM * pm, double * shift, ptrdiff_t * Nc)
 {
@@ -745,6 +774,7 @@ fastpm_store_fill(FastPMStore * p, PM * pm, double * shift, ptrdiff_t * Nc)
 
             if(p->id) p->id[ptr] = id;
             if(p->mask) p->mask[ptr] = 0;
+            if(p->rand) p->rand[ptr] = 0.;
 
             fastpm_store_get_q_from_id(p, id, &p->x[ptr][0]);
 
@@ -766,6 +796,7 @@ fastpm_store_fill(FastPMStore * p, PM * pm, double * shift, ptrdiff_t * Nc)
             );
     }
     p->meta.a_x = p->meta.a_v = 0.;
+    _fastpm_store_fill_rand(p, pm_comm(pm));
 }
 
 void
@@ -930,58 +961,16 @@ fastpm_store_extend(FastPMStore * p, FastPMStore * extra)
 void
 fastpm_store_fill_subsample_mask(FastPMStore * p,
         double fraction,
-        FastPMParticleMaskType * mask,
+	FastPMParticleMaskType * mask,
         MPI_Comm comm)
 {
-    gsl_rng * random_generator = gsl_rng_alloc(gsl_rng_ranlxd1);
-    int ThisTask;
-    MPI_Comm_rank(comm, &ThisTask);
-
-    /* set uncorrelated seeds */
-    double seed=1231584; //FIXME: set this properly.
-    gsl_rng_set(random_generator, seed);
-    int d;
-
-    for(d = 0; d < ThisTask * 8; d++) {
-        seed = 0x7fffffff * gsl_rng_uniform(random_generator);
-    }
-
-    gsl_rng_set(random_generator, seed);
 
     memset(mask, 0, p->np * sizeof(mask[0]));
 
     ptrdiff_t i;
     for(i=0; i < p->np; i++) {
-        double rand_i = gsl_rng_uniform(random_generator);
-        int flag = fraction > 1 || rand_i <= fraction;
-        mask[i] = flag;
-    }
-
-    gsl_rng_free(random_generator);
-}
-
-void
-fastpm_store_fill_subsample_mask_every_dim(FastPMStore * p,
-                                              int every, /* take 1 every 'every' per dimension */
-                                              FastPMParticleMaskType * mask)
-{
-    if(!fastpm_store_has_q(p)) {
-        /* This can be relaxed by using a less strict subsample algorithm, e.g. subsample by a hash of ID. */
-        fastpm_raise(-1, "Subsample is not supported if the store does not have meta.q.");
-    }
-    /* UNUSED */
-    memset(mask, 0, p->np * sizeof(mask[0]));
-
-    ptrdiff_t i, d;
-    for(i = 0; i < p->np; i++) {
-        ptrdiff_t pabs[3];   //pabs is the iq index. move out of loop?
-        uint64_t id = p->id[i];
-        fastpm_store_get_iq_from_id(p, id, pabs);
-
-        int flag = 1;
-        for(d = 0; d < 3; d++) {
-            flag *= !(pabs[d] % every);
-        }
+        double rand_i = p->rand[i];
+        int flag = fraction >= 1 || rand_i <= fraction;
         mask[i] = flag;
     }
 }

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -961,8 +961,7 @@ fastpm_store_extend(FastPMStore * p, FastPMStore * extra)
 void
 fastpm_store_fill_subsample_mask(FastPMStore * p,
         double fraction,
-	FastPMParticleMaskType * mask,
-        MPI_Comm comm)
+        FastPMParticleMaskType * mask)
 {
 
     memset(mask, 0, p->np * sizeof(mask[0]));

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -346,6 +346,7 @@ int run_fastpm(FastPMConfig * config, RunData * prr, MPI_Comm comm) {
 
     /* FIXME: subsample all species -- probably need different fraction for each species */
     FastPMStore * p = fastpm_solver_get_species(fastpm, FASTPM_SPECIES_CDM);
+
     fastpm_store_fill_subsample_mask(p, CONF(prr->lua, particle_fraction), p->mask, comm);
 
     FastPMUSMesh * usmesh = NULL;

--- a/tests/testfof.c
+++ b/tests/testfof.c
@@ -75,7 +75,7 @@ int main(int argc, char * argv[]) {
     fastpm_memory_free(halos->mem, ihalo);
     fastpm_store_subsample(halos, halos->mask, halos);
 
-    fastpm_store_fill_subsample_mask(p, 0.1, p->mask, solver->comm);
+    fastpm_store_fill_subsample_mask(p, 0.1, p->mask);
     ihalo = fastpm_fof_execute(&fof, linkinglength, halos_sub, p->mask);
     fastpm_memory_free(halos->mem, ihalo);
     fastpm_store_subsample(halos_sub, halos_sub->mask, halos_sub);

--- a/tests/testfunctions.sh
+++ b/tests/testfunctions.sh
@@ -1,3 +1,10 @@
+export OMP_NUM_THREADS=1
+export OMPI_MCA_rmaps_base_no_oversubscribe=0
+export OMPI_MCA_rmaps_base_oversubscribe=1
+export OMPI_MCA_mpi_yield_when_idle=1
+export OMPI_MCA_mpi_show_mca_params=1
+
+
 die () {
     exit 1
 }


### PR DESCRIPTION
The Rand column is a pseudo random number between 0-1 created for a particle at beginning of simulation.

Particle fraction uses Rand to fill a mask for subsampling before a snapshot is written out.
This change is to prepare for implementing a redshift dependent particle fraction for lightcones.
